### PR TITLE
Migrating off log4j 1.x to slf4j for logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Adding Jaydio to Your Project
 
 [jaydio-0.1.jar](https://oss.sonatype.org/service/local/repositories/releases/content/net/smacke/jaydio/0.1/jaydio-0.1.jar)
 
-Jaydio has dependencies on [JNA](https://github.com/twall/jna) and log4j.
+Jaydio has dependencies on [JNA](https://github.com/twall/jna) and [SLF4J](http://www.slf4j.org/).
 
 If you use Maven, you can add the following to your `pom.xml`:
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,9 +85,9 @@
     	<version>4.0.0</version>
     </dependency>
     <dependency>
-    	<groupId>log4j</groupId>
-    	<artifactId>log4j</artifactId>
-    	<version>1.2.17</version>
+    	<groupId>org.slf4j</groupId>
+    	<artifactId>slf4j-api</artifactId>
+    	<version>1.7.32</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/net/smacke/jaydio/DirectIoLib.java
+++ b/src/main/java/net/smacke/jaydio/DirectIoLib.java
@@ -22,7 +22,8 @@ import java.util.List;
 
 import net.smacke.jaydio.buffer.AlignedDirectByteBuffer;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.sun.jna.Native;
 import com.sun.jna.NativeLong;
@@ -42,7 +43,7 @@ import com.sun.jna.ptr.PointerByReference;
  *
  */
 public class DirectIoLib {
-    private static final Logger logger = Logger.getLogger(DirectIoLib.class);
+    private static final Logger logger = LoggerFactory.getLogger(DirectIoLib.class);
     private static boolean binit;
     
     static {


### PR DESCRIPTION
**Issue**: https://github.com/smacke/jaydio/issues/5

**Motivation**: Do not depend on unmaintained version of log4j 1.x which has a public security vulnerability https://app.snyk.io/vuln/SNYK-JAVA-LOG4J-572732, and according to https://logging.apache.org/log4j/2.x/security.html it won't be fixed in log4j 1.x.

Readme file needs to be updated after build artifacts published to maven central, and standalone jars also needs to be updated.
